### PR TITLE
 Add an optional argument to trigger update to hook (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.1] - 2019-5-8
+## [3.0.0] - 2019-5-29
+### Added
+- New optional argument to trigger an update to effect hook
+
+## [2.2.2] - 2019-5-8
 ### Changed
 - [PR from @krazyjakee](https://github.com/bitmap/react-hook-inview/pull/2)
   - Fix a bug where es6 modules cannot be compiled
@@ -49,7 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2019-2-12
 Initial release
 
-[2.2.1]: https://www.npmjs.com/package/react-hook-inview/v/2.2.1
+[3.0.0]: https://www.npmjs.com/package/react-hook-inview/v/3.0.0
+[2.2.2]: https://www.npmjs.com/package/react-hook-inview/v/2.2.2
+[2.1.0]: https://www.npmjs.com/package/react-hook-inview/v/2.1.0
 [2.0.2]: https://www.npmjs.com/package/react-hook-inview/v/2.0.2
 [2.0.1]: https://www.npmjs.com/package/react-hook-inview/v/2.0.1
 [2.0.0]: https://www.npmjs.com/package/react-hook-inview/v/2.0.0

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ npm install react-hook-inview
 
 ## Usage
 
+```js
+useInView(options, [state])
+```
+
 Hooks can only be used inside functional components.
 
 ```js
@@ -21,18 +25,18 @@ import React, { useState, useRef } from 'react'
 import { useInView } from 'react-hook-inview'
 
 const Component = () => {
-  const element = useRef()
+  const ref = useRef()
   const [isVisible, setVisible] = useState(false)
 
   useInView({
-    target: element,
+    target: ref,
     threshold: 1,
     onEnter: (entry) => setVisible(entry.isIntersecting),
     onLeave: (entry) => setVisible(entry.isIntersecting),
   })
 
   return (
-    <div ref={element}>
+    <div ref={ref}>
       {isVisible
         ? 'Hello World!'
         : ''
@@ -45,7 +49,7 @@ const Component = () => {
 ### Options
 These are the default options. `target` is the only one that's required.
 ```ts
-useInView({
+{
   target: RefObject<Element>,    // Required
   root?: Element | null,         // Optional, must be a parent of 'target' ref
   rootMargin?: string,           // '0px' or '0px 0px 0px 0px', also accepts '%' unit
@@ -53,9 +57,10 @@ useInView({
   unobserveOnEnter?: boolean,    // Set 'true' to run only once
   onEnter?: (entry?, observer?) => void, // See below
   onLeave?: (entry?, observer?) => void, // See below
-})
+}
 ```
 
+#### Callbacks
 `onEnter` and `onLeave` recieve a function that returns an `IntersectionObserverEntry` and the observer itself.
 
 ```js
@@ -68,6 +73,20 @@ function onEnter(entry, observer) {
   // entry.target
   // entry.time
 }
+```
+
+**NOTE**: If you supply an array to `threshold`, `onEnter` will be called when the element intersects with the top _and_ bottom of the viewport. `onLeave` will on trigger once the element has left the viewport at the first threshold specified.
+
+##### Accessing state in callback
+For performance reasons, the hook is only triggered once on mount/unmount. However, this means you can't access updated state in the `onEnter/onLeave` callbacks. An optional second argument will retrigger the hook to mitigate this.
+
+```js
+const [state, setState] = useState(false)
+
+useInView({
+  target: ref,
+  onEnter: () => console.log(state),
+}, [state])
 ```
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-inview",
-  "version": "2.2.2",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-inview",
-  "version": "2.2.2",
+  "version": "3.0.0",
   "description": "React Hook for detecting when an element is in the viewport",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { useEffect, RefObject } from 'react'
+import { useEffect, RefObject, ComponentState } from 'react'
 
 interface Intersect {
   (entry: IntersectionObserverEntry, observer: IntersectionObserver): void;
@@ -14,12 +14,12 @@ interface Options extends IntersectionObserverInit {
 export const useInView = ({
   target,
   root = null,
-  rootMargin = '0px',
+  rootMargin = '0px 0px 0px 0px',
   threshold = 0,
   onEnter = (): void => {},
   onLeave = (): void => {},
   unobserveOnEnter = false,
-}: Options): void => {
+}: Options, state?: ComponentState[]): void => {
   const callback: IntersectionObserverCallback = ([entry], observer): void => {
     if (entry.isIntersecting) {
       onEnter(entry, observer)
@@ -42,5 +42,5 @@ export const useInView = ({
         return observer.unobserve(target.current)
       }
     }
-  }, [])
+  }, [state ? [...state] : []])
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,5 +42,5 @@ export const useInView = ({
         return observer.unobserve(target.current)
       }
     }
-  }, [state ? [...state] : []])
+  }, state ? [...state] : [])
 }


### PR DESCRIPTION
This resolves #3. Optional second argument accepts an array that will trigger an update to the intersection observer, allowing state to be accessed on the callback.